### PR TITLE
OTP Views Changes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+show_missing = True

--- a/user/models.py
+++ b/user/models.py
@@ -66,23 +66,12 @@ class SignUpOTP(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
-    def _update_resends(self):
-        if self.is_blocked():
-            return
-
-        self.resends_used += 1
-        now = timezone.now()
-
-        if self.resends_used == OTP_MAX_RESENDS:
-            self._block_email(now)
-        self._reset_expiry(now)
-
     def _update_attempts(self):
-        if self.is_blocked():
+        if self.is_email_blocked():
             return
 
         self.attempts_used += 1
-        if self.attempts_used > OTP_MAX_ATTEMPTS:
+        if self.attempts_used >= OTP_MAX_ATTEMPTS:
             self._block_email()
 
     def _block_email(self, time_now=None):
@@ -90,34 +79,8 @@ class SignUpOTP(models.Model):
             time_now = timezone.now()
         self.blocked_until = time_now + timedelta(seconds=EMAIL_BLOCK_SECONDS)
 
-    def _reset_expiry(self, time_now=None):
-        if not time_now:
-            time_now = timezone.now()
-
-        self.expires_at = time_now + timedelta(seconds=OTP_EXPIRY_SECONDS)
-
-    def is_expired(self, time_now=None):
-        if not time_now:
-            time_now = timezone.now()
-
-        return time_now >= self.expires_at
-
-    def is_blocked(self):
-        now = timezone.now()
-        return self.blocked_until and now <= self.blocked_until
-
-    def validate_otp(self, otp_string: str):
-        self._update_attempts()
-        return self.one_time_code == otp_string
-
-    def update_otp_for_email(self):
-        self.one_time_code = generate_random_string(8)
-        self._update_resends()
-        self._reset_expiry()
-        self.save()
-
     @staticmethod
-    def create_otp_for_email(email: str, client: Application):
+    def _create_otp_for_email(email: str, client: Application):
         return SignUpOTP.objects.create(**{
             'one_time_code': generate_random_string(8),
             'email': email,
@@ -126,8 +89,59 @@ class SignUpOTP(models.Model):
         })
 
     @staticmethod
-    def get_existing_otp_or_none(email: str, client: Application):
-        return SignUpOTP.objects.filter(email=email, client=client).first()
+    def _get_otp_for_email(email: str, client: Application):
+        return SignUpOTP.objects.filter(
+            email=email,
+            client=client
+        ).first()
+
+    def reset_expiry(self, time_now=None):
+        if not time_now:
+            time_now = timezone.now()
+        self.expires_at = time_now + timedelta(seconds=OTP_EXPIRY_SECONDS)
+
+    def is_expired(self, time_now=None):
+        if not time_now:
+            time_now = timezone.now()
+
+        return time_now >= self.expires_at
+
+    def is_email_blocked(self):
+        now = timezone.now()
+        return self.blocked_until and now <= self.blocked_until
+
+    def validate_otp(self, otp_string: str):
+        self._update_attempts()
+        return self.one_time_code == otp_string
+
+    def update_resends(self):
+        if self.is_email_blocked():
+            return
+        self.resends_used += 1
+
+    def is_resend_blocked(self):
+        return self.resends_used >= OTP_MAX_RESENDS
+
+    def update_otp_for_email(self):
+        self.resends_used = 0
+        self.one_time_code = generate_random_string(8)
+
+    def num_attempts_left(self):
+        return OTP_MAX_ATTEMPTS - self.attempts_used
+
+    @classmethod
+    def get_or_create_otp(cls, email: str, client: Application):
+        return cls._get_otp_for_email(
+            email,
+            client
+        ) or cls._create_otp_for_email(
+            email,
+            client
+        )
+
+    @classmethod
+    def get_otp(cls, email: str, client: Application):
+        return cls._get_otp_for_email(email, client)
 
     def __str__(self):
         return f'{self.email}: {self.one_time_code}'

--- a/user/tests/test_otp.py
+++ b/user/tests/test_otp.py
@@ -8,11 +8,12 @@ from ..views import (
     BAD_CLIENT,
     INVALID_OTP,
     OTP_ATTEMPT_EXCEEDED,
+    OTP_RESENDS_EXCEEDED,
     OTP_EXPIRED,
     OTP_SUCCESS,
     TEMPORARY_BLOCKED_EMAIL
 )
-from ..constants import OTP_MAX_ATTEMPTS
+from ..constants import OTP_MAX_ATTEMPTS, OTP_MAX_RESENDS
 from globals.constants import ResponseMessages
 
 
@@ -31,11 +32,34 @@ class SendOTPAPITestCase(APITestCase):
         user = User.objects.create(username='oort', email='oort@oort.com')
         app = Application.objects.create(user=user, client_id=self.CLIENT_ID)
         self.url = reverse('send_otp_view')
-        self.otp_obj = SignUpOTP.objects.create(
-            email='a@b.cm',
+        self.blocked_otp_obj = SignUpOTP.objects.create(
+            email='blocked@b.cm',
             client=app,
-            expires_at=timezone.now(),
+            expires_at=timezone.now() + timedelta(days=1),
+            attempts_used=OTP_MAX_ATTEMPTS,
             blocked_until=timezone.now() + timedelta(days=1)
+        )
+        self.expired_otp_obj = SignUpOTP.objects.create(
+            email='expired@b.cm',
+            client=app,
+            expires_at=timezone.now()
+        )
+        self.resend_blocked_otp_obj = SignUpOTP.objects.create(
+            email='resend_blocked@b.cm',
+            client=app,
+            expires_at=timezone.now() + timedelta(days=1),
+            resends_used=OTP_MAX_RESENDS
+        )
+        self.almost_resend_blocked_otp_obj = SignUpOTP.objects.create(
+            email='almost_resend_blocked@b.cm',
+            client=app,
+            expires_at=timezone.now() + timedelta(days=1),
+            resends_used=OTP_MAX_RESENDS - 1
+        )
+        self.valid_otp_obj = SignUpOTP.objects.create(
+            email='valid@b.cm',
+            client=app,
+            expires_at=timezone.now() + timedelta(days=1)
         )
 
     def test_get_request(self):
@@ -46,8 +70,8 @@ class SendOTPAPITestCase(APITestCase):
         self.assertEqual(response.status_code, expected_status_code)
 
     def test_bad_client(self):
-        """Should be forbidden to access `/user/signup/send-otp/` with no client_id
-        """
+        """Should be forbidden to access `/user/signup/send-otp/`
+        with no client_id"""
         data = {'client_id': 'foobar'}
         response = self.client.post(
             self.url,
@@ -74,8 +98,8 @@ class SendOTPAPITestCase(APITestCase):
         self.assertEqual(response.data.get('message'), expected_resp_message)
 
     def test_existing_email(self):
-        """Should be forbidden for existing user to access `/user/signup/send-otp/`
-        """
+        """Should be forbidden for existing user to access
+        `/user/signup/send-otp/`"""
         data = {'client_id': self.CLIENT_ID, 'email': 'oort@oort.com'}
         response = self.client.post(
             self.url,
@@ -100,9 +124,12 @@ class SendOTPAPITestCase(APITestCase):
         self.assertEqual(response.data.get('message'), expected_resp_message)
 
     def test_blocked_email(self):
-        """Should be forbidden for blocked email to access `/user/signup/send-otp/`
-        """
-        data = {'client_id': self.CLIENT_ID, 'email': self.otp_obj.email}
+        """Should be forbidden for blocked email to access
+        `/user/signup/send-otp/`"""
+        data = {
+            'client_id': self.CLIENT_ID,
+            'email': self.blocked_otp_obj.email
+        }
         response = self.client.post(
             self.url,
             format='json',
@@ -110,17 +137,34 @@ class SendOTPAPITestCase(APITestCase):
         )
         expected_status_code = 403
         expected_resp_message = TEMPORARY_BLOCKED_EMAIL
+        self.assertEqual(self.blocked_otp_obj.attempts_used, OTP_MAX_ATTEMPTS)
         self.assertEqual(response.status_code, expected_status_code)
         self.assertEqual(response.data.get('message'), expected_resp_message)
 
-    def test_resend_expired_otp(self):
+    def test_resend_blocked(self):
+        """Should be forbidden for resend blocked email to access
+        `/user/signup/send-otp/`"""
+        data = {
+            'client_id': self.CLIENT_ID,
+            'email': self.resend_blocked_otp_obj.email
+        }
+        response = self.client.post(
+            self.url,
+            format='json',
+            data=data
+        )
+        expected_status_code = 403
+        expected_resp_message = OTP_RESENDS_EXCEEDED
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.data.get('message'), expected_resp_message)
+
+    def test_expired_otp(self):
         """Should be success to resend expired otp
         """
-        # unblock the email
-        self.otp_obj.blocked_until = None
-        self.otp_obj.save()
-
-        data = {'client_id': self.CLIENT_ID, 'email': self.otp_obj.email}
+        data = {
+            'client_id': self.CLIENT_ID,
+            'email': self.expired_otp_obj.email
+        }
         response = self.client.post(
             self.url,
             format='json',
@@ -128,17 +172,38 @@ class SendOTPAPITestCase(APITestCase):
         )
         expected_status_code = 200
         expected_resp_message = OTP_SUCCESS
+
+        obj = SignUpOTP.objects.get(email=self.expired_otp_obj.email)
+        self.assertEqual(obj.resends_used, 1)
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.data.get('message'), expected_resp_message)
+
+    def test_last_successful_resend(self):
+        """Should be success with message resend exceeded
+        on the last resend request"""
+        data = {
+            'client_id': self.CLIENT_ID,
+            'email': self.almost_resend_blocked_otp_obj.email
+        }
+        response = self.client.post(
+            self.url,
+            format='json',
+            data=data
+        )
+        expected_status_code = 200
+        expected_resp_message = OTP_RESENDS_EXCEEDED
+
+        obj = SignUpOTP.objects.get(
+            email=self.almost_resend_blocked_otp_obj.email)
+        self.assertEqual(obj.resends_used, OTP_MAX_RESENDS)
         self.assertEqual(response.status_code, expected_status_code)
         self.assertEqual(response.data.get('message'), expected_resp_message)
 
     def test_resend_otp(self):
         """Should be success on resend and return with `email` which requested
         """
-        self.otp_obj.blocked_until = None
-        self.otp_obj.expires_at = timezone.now() + timedelta(days=1)
-        self.otp_obj.save()
-
-        data = {'client_id': self.CLIENT_ID, 'email': self.otp_obj.email}
+        num_resends = self.valid_otp_obj.resends_used
+        data = {'client_id': self.CLIENT_ID, 'email': self.valid_otp_obj.email}
         response = self.client.post(
             self.url,
             format='json',
@@ -146,6 +211,9 @@ class SendOTPAPITestCase(APITestCase):
         )
         expected_status_code = 200
         expected_resp_message = OTP_SUCCESS
+
+        obj = SignUpOTP.objects.get(email=self.valid_otp_obj.email)
+        self.assertEqual(obj.resends_used, num_resends + 1)
         self.assertEqual(response.status_code, expected_status_code)
         self.assertEqual(response.data.get('message'), expected_resp_message)
 
@@ -165,11 +233,42 @@ class VerifyOTPAPITestCase(APITestCase):
             expires_at=timezone.now()
         )
 
-        self.correct_otp_obj = SignUpOTP.create_otp_for_email('a@b.mc', app)
+        self.correct_otp_obj = SignUpOTP.get_or_create_otp('a@b.mc', app)
+        self.max_attempts_otp_obj = SignUpOTP.get_or_create_otp(
+            'maxxed@b.mc', app)
+        self.blocked_otp_obj = SignUpOTP.objects.create(
+            email='blocked@bc.mc',
+            client=app,
+            expires_at=timezone.now() + timedelta(days=1),
+            attempts_used=OTP_MAX_ATTEMPTS,
+            blocked_until=timezone.now() + timedelta(days=1)
+        )
+
+    def test_get_request(self):
+        """Should not allow to request with GET at /user/signup/send-otp/
+        """
+        response = self.client.get(self.url, format='json')
+        expected_status_code = 405
+        self.assertEqual(response.status_code, expected_status_code)
+
+    def test_invalid_email(self):
+        """Should be forbidden for existing users to hit
+        `/user/signup/verify-token/`
+        """
+
+        data = {
+            'client_id': 'boofar',
+            'email': 'oort@oort.com',
+            'otp': 'random otp'
+        }
+        response = self.client.post(self.url, format='json', data=data)
+
+        expected_status_code = 403
+        self.assertEqual(response.status_code, expected_status_code)
 
     def test_bad_client(self):
-        """Should be forbidden to access `/user/signup/send-otp/` with bad `client_id`
-        """
+        """Should be forbidden to access `/user/signup/send-otp/`
+        with bad `client_id`"""
         data = {'client_id': 'foobar'}
         response = self.client.post(
             self.url,
@@ -178,6 +277,38 @@ class VerifyOTPAPITestCase(APITestCase):
         )
         expected_status_code = 403
         expected_resp_message = BAD_CLIENT
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.data.get('message'), expected_resp_message)
+
+    def test_no_otp(self):
+        """Should be a bad request when there is no otp associated with
+        email and client"""
+        data = {'client_id': 'boofar', 'email': 'aaa@aaa.com'}
+        response = self.client.post(
+            self.url,
+            format='json',
+            data=data
+        )
+        expected_status_code = 400
+        expected_resp_message = ResponseMessages.BAD_REQUEST
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.data.get('message'), expected_resp_message)
+
+    def test_blocked_email(self):
+        """Should be forbidden for blocked email to access
+        `/user/signup/send-otp/`"""
+        data = {
+            'client_id': self.CLIENT_ID,
+            'email': self.blocked_otp_obj.email
+        }
+        response = self.client.post(
+            self.url,
+            format='json',
+            data=data
+        )
+        expected_status_code = 403
+        expected_resp_message = TEMPORARY_BLOCKED_EMAIL
+        self.assertEqual(self.blocked_otp_obj.attempts_used, OTP_MAX_ATTEMPTS)
         self.assertEqual(response.status_code, expected_status_code)
         self.assertEqual(response.data.get('message'), expected_resp_message)
 
@@ -198,26 +329,36 @@ class VerifyOTPAPITestCase(APITestCase):
     def test_invalid_otp(self):
         """Should be a bad request if wrong otp is given
         """
-
+        attempts_used = self.correct_otp_obj.attempts_used
         data = {'client_id': 'boofar', 'email': 'a@b.mc', 'otp': 'wrong otp'}
         response = self.client.post(self.url, format='json', data=data)
 
         expected_status_code = 400
         expected_resp_message = INVALID_OTP
+
+        obj = SignUpOTP.objects.get(email='a@b.mc')
+        self.assertEqual(obj.attempts_used, attempts_used + 1)
         self.assertEqual(response.status_code, expected_status_code)
         self.assertEqual(response.data.get('message'), expected_resp_message)
 
     def test_otp_attempt_limit(self):
-        """Should be a bad request if OTP attepts have been exceeded
+        """Should be a bad request if OTP attempts have been exceeded
         """
 
-        data = {'client_id': 'boofar', 'email': 'a@b.mc', 'otp': 'wrong otp'}
+        data = {
+            'client_id': 'boofar',
+            'email': 'maxxed@b.mc',
+            'otp': 'wrong otp'
+        }
         response = None
-        for _ in range(OTP_MAX_ATTEMPTS + 1):
+        for _ in range(OTP_MAX_ATTEMPTS):
             response = self.client.post(self.url, format='json', data=data)
 
         expected_status_code = 400
         expected_resp_message = OTP_ATTEMPT_EXCEEDED
+
+        obj = SignUpOTP.objects.get(email='maxxed@b.mc')
+        self.assertEqual(obj.attempts_used, OTP_MAX_ATTEMPTS)
         self.assertEqual(response.status_code, expected_status_code)
         self.assertEqual(response.data.get('message'), expected_resp_message)
 
@@ -225,19 +366,18 @@ class VerifyOTPAPITestCase(APITestCase):
         """Should be a success if OTP matches
         """
 
-        data = {'client_id': 'boofar', 'email': 'a@b.mc', 'otp': self.correct_otp_obj.one_time_code}
+        data = {
+            'client_id': 'boofar',
+            'email': 'a@b.mc',
+            'otp': self.correct_otp_obj.one_time_code
+        }
         response = self.client.post(self.url, format='json', data=data)
 
         expected_status_code = 200
+        self.assertTrue(not SignUpOTP.objects.filter(email='a@b.mc').exists())
         self.assertEqual(response.status_code, expected_status_code)
-        self.assertTrue({'access_token', 'refresh_token', 'expires'} < response.data.keys())
-
-    def test_existing_user_email(self):
-        """Should be forbidden for existing users to hit `/user/signup/verify-token/`
-        """
-
-        data = {'client_id': 'boofar', 'email': 'oort@oort.com', 'otp': 'random otp'}
-        response = self.client.post(self.url, format='json', data=data)
-
-        expected_status_code = 403
-        self.assertEqual(response.status_code, expected_status_code)
+        self.assertTrue({
+            'access_token',
+            'refresh_token',
+            'expires'
+        } < response.data.keys())

--- a/user/views.py
+++ b/user/views.py
@@ -20,6 +20,7 @@ TEMPORARY_BLOCKED_EMAIL = 'This email has been temporarily blocked.' \
 BAD_CLIENT = 'Unrecognized Client'
 INVALID_OTP = 'Entered OTP wrong. Please Try Again.'
 OTP_ATTEMPT_EXCEEDED = 'OTP attempts limit exceeded. Please try after some time.'
+OTP_RESENDS_EXCEEDED = 'OTP resends limit exceeded. Please try after some time.'
 OTP_SUCCESS = 'OTP Sent Successfully.'
 OTP_EXPIRED = 'OTP has expired'
 RESET_PASSWORD_SUCCESS = 'Password Reset Successfully'
@@ -51,6 +52,17 @@ class GetCurrentUserView(views.APIView):
 class SendOTPView(views.APIView):
     permission_classes = (AllowAny,)
 
+    def send_otp(self, otp):
+        email_subject = 'HS: Please Verify your Email'
+        verification_message = get_verification_message_with_code(
+            otp.one_time_code)
+
+        send_mail.delay(
+            email_subject,
+            verification_message,
+            [otp.email]
+        )
+
     def post(self, request: Request):
         email = request.data.get('email')
         client_id = request.data.get('client_id')
@@ -70,26 +82,35 @@ class SendOTPView(views.APIView):
         if User.objects.filter(email=email).exists():
             return Response(status=status.HTTP_403_FORBIDDEN)
 
-        otp: SignUpOTP = SignUpOTP.get_existing_otp_or_none(email, client)
+        otp: SignUpOTP = SignUpOTP.get_or_create_otp(
+            email,
+            client
+        )
 
-        if not otp:
-            otp: SignUpOTP = SignUpOTP.create_otp_for_email(email, client)
-        elif otp.is_blocked():
+        error_message = None
+        if otp.is_email_blocked():
+            error_message = TEMPORARY_BLOCKED_EMAIL
+        elif otp.is_resend_blocked():
+            error_message = OTP_RESENDS_EXCEEDED
+
+        if error_message:
             return Response({
-                'message': TEMPORARY_BLOCKED_EMAIL
+                'message': error_message
             }, status.HTTP_403_FORBIDDEN)
-        elif otp.is_expired():
+
+        if otp.is_expired():
             otp.update_otp_for_email()
-        else:
-            otp._update_resends()
-            otp.save()
+            otp.reset_expiry()
 
-        verification_message = get_verification_message_with_code(otp.one_time_code)
-        send_mail.delay('HS: Please Verify your Email', verification_message, [otp.email])
+        otp.update_resends()
+        otp.save()
+        self.send_otp(otp)
 
-        return Response({
-            'message': OTP_SUCCESS
-        })
+        message = OTP_SUCCESS
+        if otp.is_resend_blocked():
+            message = OTP_RESENDS_EXCEEDED
+
+        return Response({'message': message})
 
 
 class VerifyOTPView(views.APIView):
@@ -109,14 +130,14 @@ class VerifyOTPView(views.APIView):
                 'message': BAD_CLIENT
             }, status=status.HTTP_403_FORBIDDEN)
 
-        otp: SignUpOTP = SignUpOTP.get_existing_otp_or_none(email, client)
+        otp: SignUpOTP = SignUpOTP.get_otp(email, client)
 
         if not otp:
             return Response({
                 'message': ResponseMessages.BAD_REQUEST
             }, status=status.HTTP_400_BAD_REQUEST)
 
-        elif otp.is_blocked():
+        elif otp.is_email_blocked():
             return Response({
                 'message': TEMPORARY_BLOCKED_EMAIL
             }, status=status.HTTP_403_FORBIDDEN)
@@ -132,11 +153,12 @@ class VerifyOTPView(views.APIView):
         if not otp_valid:
             error_message = INVALID_OTP
 
-            if otp.is_blocked():
+            if otp.is_email_blocked():
                 error_message = OTP_ATTEMPT_EXCEEDED
 
             return Response({
-                'message': error_message
+                'message': error_message,
+                'attempts_left': otp.num_attempts_left()
             }, status=status.HTTP_400_BAD_REQUEST)
 
         otp.delete()


### PR DESCRIPTION
- Add `attempts_left` in response.
 - BugFix: OTP can be attempted one more than the limit.
 - BugFix: OTP can't be attempted if the resend limit was exceeded which blocked the email.
 - Reset `resends_used` on renewal of an expired OTP.
 - Refactored Code.

 Closes #50 #55 #56 